### PR TITLE
Update Alpine to fix curl CVE and use latest Queens CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.8.2
 
 RUN apk add --no-cache \
   bash \
@@ -19,7 +19,7 @@ RUN apk add --no-cache \
   && pip install --no-cache-dir python-neutronclient==6.5.0  \
   && pip install --no-cache-dir python-octaviaclient==1.1.0 \
   && pip install --no-cache-dir python-swiftclient==3.6.0 \
-  && pip install --no-cache-dir python-openstackclient==3.12.0 \
+  && pip install --no-cache-dir python-openstackclient==3.14.3 \
   && pip install --no-cache-dir swiftly==2.06 \
   && apk del gcc libffi-dev libressl-dev linux-headers musl-dev
 


### PR DESCRIPTION
Quay complains about vulnerabilities in the supplier `curl`, and this updates to the latest Queens release of the CLI.